### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -18,10 +18,9 @@ class ProductsController < ApplicationController
     end
   end
 
-def show
-  @product = Product.find(params[:id])
-end
-
+  def show
+    @product = Product.find(params[:id])
+  end
 
   private
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -18,6 +18,11 @@ class ProductsController < ApplicationController
     end
   end
 
+def show
+  @product = Product.find(params[:id])
+end
+
+
   private
 
   def product_params

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -4,9 +4,9 @@ class Product < ApplicationRecord
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to :category
   belongs_to :condition
-  belongs_to :shipping_charge
+  belongs_to :shipping_charges
   belongs_to :shipping_area
-  belongs_to :shipping_day
+  belongs_to :shipping_days
 
   validates :image, :name, :status, presence: true
 

--- a/app/models/shipping_charge.rb
+++ b/app/models/shipping_charge.rb
@@ -1,4 +1,4 @@
-class ShippingCharge < ActiveHash::Base
+class ShippingCharges < ActiveHash::Base
   self.data = [
     { id: 1, name: '--' },
     { id: 2, name: '着払い（購入者負担）' },

--- a/app/models/shipping_day.rb
+++ b/app/models/shipping_day.rb
@@ -1,4 +1,4 @@
-class ShippingDay < ActiveHash::Base
+class ShippingDays < ActiveHash::Base
   self.data = [
     { id: 1, name: '--' },
     { id: 2, name: '１日〜２日で発送' },

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -128,7 +128,7 @@
     <% if @products.present? %> 
       <% @products.each do |product| %>
       <li class='list'>
-        <%= link_to "#" do %>
+         <%= link_to product_path(product.id), method: :get do %> 
         <div class='item-img-content'>
           <%= image_tag product.image, class:"item-img"%>
 
@@ -152,7 +152,7 @@
           </div>
         </div>
         <% end %>
-        <% end %>
+        <% end %> 
       
       </li>
        <% else %>

--- a/app/views/products/new.html.erb
+++ b/app/views/products/new.html.erb
@@ -71,7 +71,7 @@
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:shipping_charges_id,ShippingCharge.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:shipping_charges_id,ShippingCharges.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
@@ -81,7 +81,7 @@
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:shipping_days_id,ShippingDay.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:shipping_days_id,ShippingDays.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -4,7 +4,7 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%=  @product.name  %>
     </h2>
     <div class='item-img-content'>
       <%= image_tag @product.image ,class:"item-box-img" %>
@@ -19,26 +19,23 @@
         <%= @product.price %>
       </span>
       <span class="item-postage">
-        <%= '配送料負担' %>
+        <%= @product.shipping_charges.name %>
       </span>
     </div>
 
-    <% if user_signed_in? %> <%# <% if 'ユーザーがログインしているかどうか' %>
-    <% if current_user == @product.user%> <%# <% if '商品詳細画面にアクセスしたユーザーが出品者かどうか' %>  
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-     <% elsif @product.user_id.present?  %>  
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-    <% end %>
+    <% if user_signed_in? %> 
+      <% if current_user == @product.user%> 
+          <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+          <p class='or-text'>or</p>
+          <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+      <% elsif @product.user_id.present?  %>  
+          <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+      <% end %>
     <% end %> 
 
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @product.status %></span>
     </div>
     <table class="detail-table">
       <tbody>
@@ -103,7 +100,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class='another-item'><%= @product.category.name%>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -44,27 +44,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @product.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @product.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @product.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @product.shipping_charges.name%></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          < <td class="detail-value"><%= @product.shipping_area_id %></td> 
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <<td class="detail-value"><%= @product.shipping_days_id%></td> 
         </tr>
       </tbody>
     </table>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -60,11 +60,11 @@
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          < <td class="detail-value"><%= @product.shipping_area_id %></td> 
+          < <td class="detail-value"><%= @product.shipping_area.name %></td> 
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <<td class="detail-value"><%= @product.shipping_days_id%></td> 
+          <<td class="detail-value"><%= @product.shipping_days.name%></td> 
         </tr>
       </tbody>
     </table>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -60,11 +60,11 @@
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          < <td class="detail-value"><%= @product.shipping_area.name %></td> 
+           <td class="detail-value"><%= @product.shipping_area.name %></td> 
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <<td class="detail-value"><%= @product.shipping_days.name%></td> 
+          <td class="detail-value"><%= @product.shipping_days.name%></td>  
         </tr>
       </tbody>
     </table>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -1,0 +1,109 @@
+<%= render "shared/header" %>
+
+<%# 商品の概要 %>
+<div class="item-show">
+  <div class="item-box">
+    <h2 class="name">
+      <%= "商品名" %>
+    </h2>
+    <div class='item-img-content'>
+      <%= image_tag @product.image ,class:"item-box-img" %>
+      <%# 商品が売れている場合は、sold outを表示しましょう %>
+      <div class='sold-out'>
+        <span>Sold Out!!</span>
+      </div>
+      <%# //商品が売れている場合は、sold outを表示しましょう %>
+    </div>
+    <div class="item-price-box">
+      <span class="item-price">
+        <%= @product.price %>
+      </span>
+      <span class="item-postage">
+        <%= '配送料負担' %>
+      </span>
+    </div>
+
+    <% if user_signed_in? %> <%# <% if 'ユーザーがログインしているかどうか' %>
+    <% if current_user == @product.user%> <%# <% if '商品詳細画面にアクセスしたユーザーが出品者かどうか' %>  
+    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+    <p class='or-text'>or</p>
+    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+     <% elsif @product.user_id.present?  %>  
+    <%# 商品が売れていない場合はこちらを表示しましょう %>
+    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+    <%# //商品が売れていない場合はこちらを表示しましょう %>
+    <% end %>
+    <% end %> 
+
+    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+
+    <div class="item-explain-box">
+      <span><%= "商品説明" %></span>
+    </div>
+    <table class="detail-table">
+      <tbody>
+        <tr>
+          <th class="detail-item">出品者</th>
+          <td class="detail-value"><%= "出品者名" %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">カテゴリー</th>
+          <td class="detail-value"><%= "カテゴリー名" %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">商品の状態</th>
+          <td class="detail-value"><%= "商品の状態" %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">配送料の負担</th>
+          <td class="detail-value"><%= "発送料の負担" %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">発送元の地域</th>
+          <td class="detail-value"><%= "発送元の地域" %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">発送日の目安</th>
+          <td class="detail-value"><%= "発送日の目安" %></td>
+        </tr>
+      </tbody>
+    </table>
+    <div class="option">
+      <div class="favorite-btn">
+        <%= image_tag "star.png" ,class:"favorite-star-icon" ,width:"20",height:"20"%>
+        <span>お気に入り 0</span>
+      </div>
+      <div class="report-btn">
+        <%= image_tag "flag.png" ,class:"report-flag-icon" ,width:"20",height:"20"%>
+        <span>不適切な商品の通報</span>
+      </div>
+    </div>
+  </div>
+  <%# /商品の概要 %>
+
+  <div class="comment-box">
+    <form>
+      <textarea class="comment-text"></textarea>
+      <p class="comment-warn">
+        相手のことを考え丁寧なコメントを心がけましょう。
+        <br>
+        不快な言葉遣いなどは利用制限や退会処分となることがあります。
+      </p>
+      <button type="submit" class="comment-btn">
+        <%= image_tag "comment.png" ,class:"comment-flag-icon" ,width:"20",height:"25"%>
+        <span>コメントする<span>
+      </button>
+    </form>
+  </div>
+  <div class="links">
+    <a href="#" class="change-item-btn">
+      ＜ 前の商品
+    </a>
+    <a href="#" class="change-item-btn">
+      後ろの商品 ＞
+    </a>
+  </div>
+  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
+</div>
+
+<%= render "shared/footer" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root to: "products#index"
-  resources :products, only: [:index, :new,:create]
+  resources :products, only: [:index, :new,:create,:show]
 end


### PR DESCRIPTION
What
商品詳細表示

Why
実際ユーザーが出品の購入や編集や削除をするとき
詳細画面で実装するため
ログイン状態の出品者のみ、「編集・削除ボタン」が表示されること
https://gyazo.com/f9050583c08cb68606f298c3546c11d3
ログイン状態の出品者以外のユーザーのみ、「購入画面に進むボタン」が表示されること
https://gyazo.com/e91c556eb8a6d1cda183a439cbadc91d
ログアウト状態のユーザーでも、商品詳細表示ページを閲覧できること
ログアウト状態のユーザーには、「編集・削除・購入画面に進むボタン」が表示されないこと
https://gyazo.com/ef88873c6d7e95793e885758bce614e6

確認お願いします